### PR TITLE
Fix panic to avoid warning message

### DIFF
--- a/src/gleamy/bench.gleam
+++ b/src/gleamy/bench.gleam
@@ -1,12 +1,12 @@
-import gleam/int
 import gleam/float
+import gleam/int
+import gleam/io
 import gleam/list
 import gleam/string
-import gleam/io
 
 @external(erlang, "os", "perf_counter")
 fn perf_counter(_resolution: Int) -> Int {
-  panic("not implemented")
+  panic as "not implemented"
 }
 
 /// timestamp in milliseconds

--- a/src/gleamy_bench_example.gleam
+++ b/src/gleamy_bench_example.gleam
@@ -1,7 +1,7 @@
-import gleamy/bench
-import gleam/io
 import gleam/int
+import gleam/io
 import gleam/list
+import gleamy/bench
 
 fn sort_int(data) {
   list.sort(data, int.compare)


### PR DESCRIPTION
This avoids the following error message on gleam v1.2.1.

```
warning: Panic used as a function
  ┌─ /Users/kevinrobell/Desktop/other/Coding/Projects/persistent_regex/bench/build/packages/gleamy_bench/src/gleamy/bench.gleam:9:9
  │
9 │   panic("not implemented")
  │         ^^^^^^^^^^^^^^^^^

`panic` is not a function and will crash before it can do anything with
this argument.

Hint: if you want to display an error message you should write
`panic as "my error message"`
See: https://tour.gleam.run/advanced-features/panic/
```

The other changes are just because `gleam format` now sorts imports alphabetically.