### PR TITLE
Fix deprecation errors due to stdlib

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -10,7 +10,7 @@ repository = { type = "github", user = "schurhammer", repo = "gleamy_bench" }
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.32"
+gleam_stdlib = ">= 0.42.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
+gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,8 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.35.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5443EEB74708454B65650FEBBB1EF5175057D1DEC62AEA9D7C6D96F41DA79152" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
+  { name = "gleam_stdlib", version = "0.54.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "723BA61A2BAE8D67406E59DD88CEA1B3C3F266FC8D70F64BE9FEC81B4505B927" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,5 +7,5 @@ packages = [
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.32" }
-gleeunit = { version = "~> 1.0" }
+gleam_stdlib = { version = ">= 0.42.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/gleamy/bench.gleam
+++ b/src/gleamy/bench.gleam
@@ -202,16 +202,16 @@ fn format_float(f: Float, decimals: Int) {
   let whole = float.truncate(f)
   let decimal = float.truncate(f *. factor) - whole * float.truncate(factor)
   string.concat([
-    string.pad_left(int.to_string(whole), stat_pad - decimals - 1, " "),
+    string.pad_start(int.to_string(whole), stat_pad - decimals - 1, " "),
     ".",
-    string.pad_left(int.to_string(decimal), decimals, "0"),
+    string.pad_start(int.to_string(decimal), decimals, "0"),
   ])
 }
 
 fn header_row(stats: List(Stat)) -> String {
   [
-    string.pad_right("Input", name_pad, " "),
-    string.pad_right("Function", name_pad, " "),
+    string.pad_end("Input", name_pad, " "),
+    string.pad_end("Function", name_pad, " "),
     ..list.map(stats, fn(stat) {
       let stat = case stat {
         P(n) -> "P" <> int.to_string(n)
@@ -223,7 +223,7 @@ fn header_row(stats: List(Stat)) -> String {
         SDPercent -> "SD%"
         Stat(name, _) -> name
       }
-      string.pad_left(stat, stat_pad, " ")
+      string.pad_start(stat, stat_pad, " ")
     })
   ]
   |> string.join("")
@@ -231,8 +231,8 @@ fn header_row(stats: List(Stat)) -> String {
 
 fn stat_row(set: Set, stats: List(Stat), options: Options) -> String {
   [
-    string.pad_right(set.input, name_pad, " "),
-    string.pad_right(set.function, name_pad, " "),
+    string.pad_end(set.input, name_pad, " "),
+    string.pad_end(set.function, name_pad, " "),
     ..list.map(stats, fn(stat) {
       let stat = case stat {
         P(n) -> percentile(n, set.reps)
@@ -247,7 +247,7 @@ fn stat_row(set: Set, stats: List(Stat), options: Options) -> String {
       }
       stat
       |> format_float(options.decimals)
-      |> string.pad_left(stat_pad, " ")
+      |> string.pad_start(stat_pad, " ")
     })
   ]
   |> string.join("")


### PR DESCRIPTION
Hello!

`pad_start` and `pad_end` where deprecated and renamed with gleam_stdlib@0.42.0, and removed completely in version 0.54.0.

I really like gleamy_bench and use it a lot, and it would be even better if I could use the latest version of the standard library with it too!

Thank you ~ yoshi :purple_heart: